### PR TITLE
Bump socks-client to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>sockjs-client</artifactId>
-    <version>0.3.4-2-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>SockJS-client</name>
     <description>WebJar for SockJS-client</description>
     <url>http://webjars.org</url>
@@ -41,7 +41,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.3.4</upstream.version>
+        <upstream.version>1.0.0</upstream.version>
         <upstream.url>http://cdn.sockjs.org/</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>sockjs-client</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>SockJS-client</name>
     <description>WebJar for SockJS-client</description>
     <url>http://webjars.org</url>


### PR DESCRIPTION
sockjs-client1.0.0 is released.
https://github.com/sockjs/sockjs-client/releases/tag/v1.0.0